### PR TITLE
feat: add 'repeat' property to the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ by means of a simple configuration file.
 
 ### Usage
 
-``` python
+```python
 python emulate.py --config configs/example.json --output output.json
 ```
 
 Where:
 
-* `config`: this is the path to the configuration file that must have been properly built in order to avoid errors.
-* `output`: this is an optional parameter that when present, creates a `json` file with the information about the timestamp and conditions applied.
+- `config`: this is the path to the configuration file that must have been properly built in order to avoid errors.
+- `output`: this is an optional parameter that when present, creates a `json` file with the information about the timestamp and conditions applied.
 
 ### Configuration Files
 
@@ -56,19 +56,21 @@ The configuration files have the following structure:
 
 `interface`: interface where the network conditions will be applied.
 
+`repeat`: number of times the experiment will be repeated. Can be either a number, or `forever` to repeat the experiment until the user stops it.
+
 `events`: list of ordered network conditions.
 
 Each `event` should be tagged by an integer that indicates the order. The
 range should be from 1 to N, being N the number of events that will be applied.
 
-Inside the event `duration` indicates in milliseconds the duration of the 
+Inside the event `duration` indicates in milliseconds the duration of the
 network conditions.
 
-`rules` is a list of the conditions that will be applied during the event. 
+`rules` is a list of the conditions that will be applied during the event.
 This is where the filters from `tc-netem` should be written. For more info,
 take a look at the [tc-netem docs](http://man7.org/linux/man-pages/man8/tc-netem.8.html).
 
-A special rule, that has nothing to do with the `tc-netem` commands has been 
+A special rule, that has nothing to do with the `tc-netem` commands has been
 created. This rule means that all conditions will be cleared. It is recommended
 to always have this rule as the last one to make sure the network conditions are
 cleared once the simulation has been finished. It can also be used to add
@@ -86,13 +88,11 @@ the interface `wlp3s0`. It has a total of 4 events:
 
 1. The first event lasts 5 seconds and there are no conditions applied.
 2. Applies a delay that follows a gaussian distribution of mean 30ms and
-standard deviation (jitter) of 10ms. It also adds a 0.1% packet loss with
-a correlation of 0.25%. This correlation is used to simulate burst errors. This
-event has a duration of 15 seconds.
+   standard deviation (jitter) of 10ms. It also adds a 0.1% packet loss with
+   a correlation of 0.25%. This correlation is used to simulate burst errors. This
+   event has a duration of 15 seconds.
 3. This event is 10 second long and adds a constant 50ms delay.
 4. The simulation is finished by 5 seconds of cleared conditions.
-
-
 
 ### Notes
 

--- a/configs/repeating_example.json
+++ b/configs/repeating_example.json
@@ -1,0 +1,32 @@
+{
+  "name": "example",
+  "interface": "wlp3s0",
+  "repeat": 5,
+  "events": {
+    "1": {
+      "duration": 5000,
+      "rules": [
+        "clear"
+      ]
+    },
+    "2": {
+      "duration": 15000,
+      "rules": [
+        "delay 30ms 10ms distribution normal",
+        "loss 0.1% 0.25%"
+      ]
+    },
+    "3": {
+      "duration": 10000,
+      "rules": [
+        "delay 50ms"
+      ]
+    },
+    "4": {
+      "duration": 5000,
+      "rules": [
+        "clear"
+      ]
+    }
+  }
+}

--- a/emulate.py
+++ b/emulate.py
@@ -3,7 +3,7 @@ import time
 import argparse
 import os
 from datetime import datetime
-
+import math
 
 def load_config(path: str) -> dict:
     with open(path) as json_file:
@@ -50,6 +50,11 @@ def apply_condition(interface: str, event: dict, is_cleared: bool):
 
     return cleared
 
+def get_repeat(config: dict):
+    repeats = config.get('repeat', 1)
+    if repeats == 'forever':
+        return math.inf
+    return repeats
 
 if __name__ == '__main__':
 
@@ -68,14 +73,22 @@ if __name__ == '__main__':
 
     print('Configuration file read:')
     print(config, '\n')
-    timeline = execute_experiment(config)
 
-    if args.output:
-        print(f'Creating output file {args.output}')
-        with open(args.output, 'w') as outfile:
-            json.dump(timeline, outfile)
-    else:
-        print('No output file.')
+    repeat = get_repeat(config)
+    i = 0
+    while repeat - i > 0:
+        print(f'Executing experiment {i + 1} of {repeat}')
+        timeline = execute_experiment(config)
+
+        if args.output:
+            output_file_name = f'{args.output}.json' if i == 0 else f'{args.output}_{i}.json'
+            print(f'Creating output file {output_file_name}')
+            with open(output_file_name, 'w') as outfile:
+                json.dump(timeline, outfile)
+        else:
+            print('No output file.')
+
+        i += 1
 
 
 


### PR DESCRIPTION
I added a 'repeat' property to the config, so I can re-run the same experiment continuously.